### PR TITLE
Add clients to examples & fix deserializing.

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -4,6 +4,7 @@
 ///! $ cargo run --example main -- <HOST> <API_USER> <API_PASSWORD>
 ///! ```
 use std::{env, error::Error};
+use std::{net::IpAddr, str::FromStr};
 
 use colored::Colorize;
 use prettytable::*;
@@ -75,6 +76,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
       network.name,
       network.network.unwrap_or_else(|| "-".to_string()),
       network.passphrase.unwrap_or_else(|| "-".to_string())
+    ]);
+  }
+  table.printstd();
+
+  print_section("7/ CLIENTS");
+  let mut table = new_table(row![b -> "Name", b -> "IP", b -> "MAC"]);
+  for client in unifi.clients("default").await? {
+    table.add_row(row![
+      client.name.unwrap_or_else(|| "-".to_string()),
+      client.ip.unwrap_or(IpAddr::from_str("0.0.0.0")?),
+      client.mac,
     ]);
   }
   table.printstd();

--- a/src/clients/types.rs
+++ b/src/clients/types.rs
@@ -20,8 +20,11 @@ pub(super) struct RemoteClient {
   pub last_seen: Option<i64>,
   pub is_wired: bool,
   pub is_guest: bool,
+  #[serde(default)]
   pub authorized: bool,
+  #[serde(default)]
   pub rx_bytes: u64,
+  #[serde(default)]
   pub tx_bytes: u64,
   #[serde(rename = "wired-rx_bytes", default)]
   pub wired_rx_bytes: u64,


### PR DESCRIPTION
This works against a UDM Pro running 7.1.65

Networks don't however as the dhcp_lease_time is coming across as a string not a u64.